### PR TITLE
various textual cleanup

### DIFF
--- a/_sources/contractor/ConfigurationValues.txt
+++ b/_sources/contractor/ConfigurationValues.txt
@@ -1,18 +1,18 @@
 Configuration Values
 ====================
 
-config value key names must match the regex::
+Config value key names must match the regex::
 
   ^[<>\-~]?([a-zA-Z0-9]+:)?[a-zA-Z0-9][a-zA-Z0-9_\-]*$
 
-if the first charater is: (also processed in this order)
+If the first character is: (also processed in this order)
   - : remove from the value so far
   <nothing> : overlay/replace value so far with new value
   < : prepend to the value so far (same affect as append on dict/maps)
   > : append to the value so far
   ~ : mask/remove value so far, (NOTE: value is ignored)
 
-if [a-zA-Z0-9]+: is present, the value key/value is only applied if the pre ':'
+If [a-zA-Z0-9]+: is present, the value key/value is only applied if the pre ':'
 matches the classes indicated by the foundation.  This is the **_foundation_class_list**
 
 Global and Config Attributes
@@ -20,14 +20,14 @@ Global and Config Attributes
 
 To help indicate Attributes and to keep them from getting overwritten by config values
 ( config values are not allowed to start with `_` ), Global attributes begin with `__`
-and other attributes begine with `_`.  Attributes also do not follow the value combining
+and other attributes begin with `_`.  Attributes also do not follow the value combining
 rules, as they are set internally.  They are also not affected by config classes.
 
 
 Value Merging
 -------------
 
-Configvalues are merged using Jinja2. They are merged togeather as a final step
+Configvalues are merged using Jinja2. They are merged together as a final step
 before outputting and before merging with a PXE or Boot template.
 
 For documentation on Jina2 see http://jinja.pocoo.org/
@@ -54,7 +54,7 @@ Becomes::
   dns_search: [ 'site1.local', 'local' ]
   dns_zone: 'site1.local'
 
-NOTE:  There is not sorting nor predictable order, becarefull when embeding/refrencing,
+NOTE:  There is not sorting nor predictable order, be careful when embeding/referencing,
 you may get random results.  A second (or more) evaluation round can be forced by escaping
 the '{{' ie::
 
@@ -67,10 +67,10 @@ the result will be::
 Value Overlay Rules
 -------------------
 
-For Site and BluePrint, the values of the parents are overlied by the children.
+For Site and BluePrint, the values of the parents are overlaid by the children.
 
 
-Sources of Configuraion Values
+Sources of Configuration Values
 ------------------------------
 
 In general the order is blueprint, attributes, config values, and global attributes
@@ -81,29 +81,29 @@ For a Site
   Global attribute values
 
 For a Foundation
-  Foundation's BluePrint (with it's parents applied)
+  Foundation's BluePrint (with its parents applied)
   Foundation's attribute values (including values from a complex, if Foundation belongs to a complex)
-  Site (with it's parents applied)
+  Site (with its parents applied)
   Global attribute values
 
 For a Structure
-  Structures's BluePrint (with it's parents applied)
+  Structures's BluePrint (with its parents applied)
   Foundation's attribute values NOTE: the Foundation's BluePrint values are NOT used, these are only for
-                                      the physicall provisioning of the Foundation, ie: BIOS settings, the
+                                      the physical provisioning of the Foundation, ie: BIOS settings, the
                                       Structure can specify values for the Foundation by which FoundationBluePrints
                                       the Structure BluePrint supports
                                NOTE2: also includes the complex values, if the foundation belongs
                                       to a complex
-  Site (with it's parents applied)
+  Site (with its parents applied)
   Structure's attribute values
   Structure's config_values
   Global attribute values
 
 
 NOTE:
-  Sites configs are applied from the top most parent down with the child overlaing the parent.
-  BluePrint configs are applied Top down, and across each leayer, the order of sibilings is not predictable.
-  BluePrint scripts are searched BFS (Breath First Search), the order of sibilings is not predictable.
+  Site configs are applied from the top most parent down with the child overlaying the parent.
+  BluePrint configs are applied Top down, and across each layer, the order of siblings is not predictable.
+  BluePrint scripts are searched BFS (Breadth First Search), the order of siblings is not predictable.
 
 Attribute Values
 ----------------
@@ -118,9 +118,9 @@ Global attribute values
 -----------------------
 
 These values start with `__` and are not overlayable/modifyable by config_values.  These
-values are things that are global to this install of contrator,  such as the base url
+values are things that are global to this install of Contractor,  such as the base url
 to use to contact it.  `__last_modified` is also added, which is the timestamp of
-the most reset modification date to any of the sources of configuratoin information.
+the most recent modification date to any of the sources of configuration information.
 
 
 Example
@@ -161,7 +161,7 @@ provide more attribute values than what is shown)::
   | +----------+-----------+                  |
   | |                      |                  |
   | | Foundation:          |                  |
-  | |   Locater: d2r050u20 |                  |
+  | |   Locator: d2r050u20 |                  |
   | |                      |                  |
   | +----------------------+                  |
   |                                           |
@@ -194,7 +194,7 @@ One last thing we forgot, the blueprints::
   | +----------+-------------+                |    |                                                                      |
   | |                        +---------------------+ Small VM Foundation BluePrint:                                       |
   | | Foundation:            |                |    |   cpu_count: 2                                                       |
-  | |   Locater: 'd2r050u20' |                |    |   memory: 1024                                                       |
+  | |   Locator: 'd2r050u20' |                |    |   memory: 1024                                                       |
   | |                        |                |    |                                                                      |
   | +------------------------+                |    +----------------------------------------------------------------------+
   |                                           |
@@ -219,7 +219,7 @@ And the Foundation's Config Values are::
   memory: 1024
   _foundation_locator: 'd2r050u20'
 
-Everythnig was fine till our web site got busy, time to expand.  First let's
+Everything was fine until our web site got busy, time to expand.  First let's
 move our server to a sub-site and create another sub-site with it's own
 web server::
 
@@ -244,7 +244,7 @@ web server::
   | | +----------+-------------+                |  | +----------+-------------+                | |   |                                                                      |
   | | |                        +---------------------+                        +----------------------+ Small VM Foundation BluePrint:                                       |
   | | | Foundation:            |                |  | | Foundation:            |                | |   |   cpu_count: 2                                                       |
-  | | |   Locater: 'd2r050u20' |                |  | |   Locater: 'd2r020u20' |                | |   |   memory: 1024                                                       |
+  | | |   Locator: 'd2r050u20' |                |  | |   Locator: 'd2r020u20' |                | |   |   memory: 1024                                                       |
   | | |                        |                |  | |                        |                | |   |                                                                      |
   | | +------------------------+                |  | +------------------------+                | |   +----------------------------------------------------------------------+
   | |                                           |  |                                           | |
@@ -274,9 +274,9 @@ And Site 2's Structure is::
 
 At some point in the future we add another DNS server, we can add it to the top
 level and it will propagate to everything automatically.  Actually a better DNS
-design would be to add dns servers to site1 and site 2 and prepend thoes to the
+design would be to add dns servers to Site 1 and Site 2 and prepend those to the
 dns server list.  Also if we want another global dns search zone to come after
-'myservice.com', we can add it to the list at the top, and once again.  It will
-Propagate for us.  If there is a site that you do not want to  inherit the
-top level dns_search, you  would omit the **{** from the name, and the value will
-overwrite instead of pre-pend
+'myservice.com', we can add it to the list at the top, and once again it will
+propagate for us.  If there is a site that you do not want to inherit the
+top level dns_search, you would omit the **{** from the name, and the value will
+overwrite instead of pre-pend.

--- a/_sources/contractor/Introduction.txt
+++ b/_sources/contractor/Introduction.txt
@@ -1,19 +1,19 @@
 Introduction to Contractor
 ==========================
 
-The Goal of Contractor is to provide a Universial Interface/API to Automate
-Mangment, Provisioning, Deploying, and Configuration of Resource.
+The Goal of Contractor is to provide a Universal Interface/API to Automate
+Management, Provisioning, Deploying, and Configuration of Resource.
 
 Contractor uses building terms (for the most part) to try to avoid name
 colisions with various platforms and systems.
 
 First two terms are **Foundation** and **Structure**.  A Foundation is something
-to build on, a structure is that things you want to  build.  Say we want to
+to build on, a Structure is the thing you want to build.  Say we want to
 build a Web Server.  Our Structure is a set of configuration values and scripts
-required to build that web server, ie: Install Ubuntu LTS 18.04 and install and
-Configure Apache (more on thoes deatils in .....).  The Foundation is what we
-want to install that on, ie: a VM, Container, Blade Server, Baremetal Server,
-Rasbery PI, ECS, GCD, etc...  Not all Foundations are going to be compatiable
+required to build that web server, i.e., Install Ubuntu LTS 18.04 and install and
+Configure Apache (more on thoes details in .....).  The Foundation is what we
+want to install that on, i.e., a VM, Container, Blade Server, Baremetal Server,
+Rasbery PI, ECS, GCD, etc...  Not all Foundations are going to be compatible
 with all Structures, however a well defined Structure can be installed on most
 of them.
 
@@ -56,9 +56,9 @@ our Web Server in a Site called "Cluster 1"
   |                                     |
   +-------------------------------------+
 
-Each Item we have used so far containes configuration values.  These are Key
+Each Item we have used so far contains configuration values.  These are Key
 Value pairs that can be overlayed.  In this case Contractor will take the
-configuration values of "Cluster 1" then over lay them with "Foundation" and
+configuration values of "Cluster 1" then overlay them with "Foundation" and
 the "Structure".
 
 Sites can be be put into other Sites.  For example we have Clusters 1, 2, and 3
@@ -91,22 +91,22 @@ in "Datacenter West".
 
 Now the configuration information will first have site "Datacenter West" then,
 Cluster X, Foundation, Structure.  This comes in handy for propagating configuration
-information without having to set it for each item indivitually.  For Example
+information without having to set it for each item individually.  For example,
 we can have the DNS Search Zones be set to "west.site.com" in the site "Datacenter West"
 and prepend that with "cluster1.site.com" in "Cluster 1".  If at any time we want
 some other global DNS search zone, we add it to the top and it automatically propagates
-down.   You could also set "Release"="Prod" in "Datacenter West" and then create a
+down.  You could also set "Release"="Prod" in "Datacenter West" and then create a
 "Cluster Test" and override the "Release" to the value "Test".  You could also do
 A-B testing, etc.
 
-Any Item can make a http request to contractor and contractor will reply with a JSON
-encoded reply with that items combined configuration values.
+Any Item can make an http request to Contractor and Contractor will reply with a JSON
+encoded reply with that item's combined configuration values.
 
-This is all fun and all, but not really usefull.  Let's change things up abit and
+This is all fun and all, but not really useful.  Let's change things up a bit and
 install ESX on the baremetal and put a few Web servers on ESX.
 
-Before we do that we need to dig into foundations a little more. The **Foundation**
-class is meant as a root class for specific target handelers to work against.
+Before we do that we need to dig into Foundations a little more. The **Foundation**
+class is meant as a root class for specific target handlers to work against.
 
 We are going to use the **IPMIFoundation** to handle the baremetal machines on which
 we are installing ESX on, and **VCenterFoundation** to handle the vms on the
@@ -157,10 +157,10 @@ Note: we are going to omit Cluster 2 and 3 for now, they are clones of Cluster 1
   +-----------------------------------------------------------------------------+
 
 This introduces our next item the **Complex** as in a building complex.  A Complex
-is a group of structures providing something for more Foundations to be built on.
-A Complex (dependingon the type) can have one or more structures as members.
-NOTE: the configuration info of the structure and foundations that make up a
-cluster do **NOT** flow through to the foundations and structures built on that
+is a group of Structures providing something for more Foundations to be built on.
+A Complex (depending on the type) can have one or more Structures as members.
+NOTE: the configuration info of the Structure and Foundations that make up a
+cluster do **NOT** flow through to the Foundations and Structures built on that
 complex.  The Members of the Complex can even belong to another site.
 
 For Example::
@@ -213,67 +213,67 @@ For Example::
   +-----------------------------------------------------------------------------+
 
 Complexes also cause Contractor to build the Web Server Structure/Foundations
-after the ESX Structure/Foundations are done.  Also the exmaple would look pretty
+after the ESX Structure/Foundations are done.  Also the example would look pretty
 much the same for a Docker/OpenStack/etc Complex.
 
 Side Track to the Manefesto
 ---------------------------
 
 At this point you are probably wondering how having all these Foundation types
-is simplifying deployments.  By Seperating the configuration of the "Hosted" and
-the "Host" we can effectivly divide up the job of configuraing the sytem.  (Do
-I get to drop the DevOps Buzzword now?)  As a Developer/Enginner configures their
-code, the embody that in a structure.  They can package that configuration
+is simplifying deployments.  By separating the configuration of the "Hosted" and
+the "Host" we can effectively divide up the job of configuraing the sytem.  (Do
+I get to drop the DevOps Buzzword now?)  As a Developer/Engineer configures their
+code, they embody that in a Structure.  They can package that configuration
 information along with their code/designs and that configuration can also
-be tested and verified via CICD and simmaler work flows.  This way the very
+be tested and verified via CICD and similar work flows.  This way the very
 same configuration information is for all stages of deployment.  It is true
-that some foundations require different considerations, however a well designed
+that some Foundations require different considerations, however a well designed
 Structure Configuration can work for Containers (and the like) as well as
-OS installes (Baremetal/VM/Blade/AWS, etc.)  Now we the Operations people need to
+OS installers (Baremetal/VM/Blade/AWS, etc.)  Now when the Operations people need to
 turn it up to 11 (or 12) they just pick the location to deploy and no matter if
-it is hosted on prem in VMs, or deployed to AWS for some peak load handeling,
-Operations can scale as needed, to what ever.
+it is hosted on prem in VMs, or deployed to AWS for some peak load handling,
+Operations can scale as needed, to whatever.
 
 Also by allowing every thing, no matter the platform, to be tracked in the same
-place.  You now have a single source of truth for your monitoring sytem to rely on.
-And you don't have to worry about parts of your Micro Services failing to auto-register.
-And you know exactly what is deployed where, usefull when hardware needs to be
+place, you now have a single source of truth for your monitoring sytem to rely on.
+You don't have to worry about parts of your Micro Services failing to auto-register.
+And, you know exactly what is deployed where; useful when hardware needs to be
 swapped out.
 
 Your Operations teams are also free to try changing out hosting solutions without
-retooling everything to try it.  And in some cases without involving Enginerring
+retooling everything to try it -- in some cases without involving Engineering
 to do so.
 
-Not only can you unify your provivsioning tools, but also the auto-scaling tools.
+Not only can you unify your provisioning tools, but also the auto-scaling tools.
 
-You are also free from vendor lock in.  If a new Cloud provier comes along, they
-don't need to have a AWS like API to use them, just a Foundation subclass
+You are also free from vendor lock in.  If a new Cloud provider comes along, they
+don't need to have an AWS like API to use them, just a Foundation subclass
 provider that talks to that Cloud provider's API and you are set.  Same if
 a new class of hardware comes along (ARM servers anyone ;-) ) or a new way of
-approcing hosting (the next thing after containers).  You can truly be
-"serverless" (I know another buzzword, meaning your deyployments are agnostic
-as to the techonlogy they are being deployed on).  And you don't have to try to
+approaching hosting (the next thing after containers).  You can truly be
+"serverless" (I know another buzzword, meaning your deployments are agnostic
+as to the technology they are being deployed on).  And you don't have to try to
 fit all your use cases into one silver bullet.  You can have a nice auto-scaling
 Container Cloud/Swarm with your micro services right next to standard VMs running
 the databases and object storage.  All with one "pane of glass"
 
-Ok back to business, buzzword dropping disabled...
+Ok, back to business, buzzword dropping disabled...
 
 Back to business
 ----------------
 
-One final piece of the deployment puzzle, the **Dependancy**.  This is to make sure
-your deployments happen in order.  For example, you can't install any OSes untill
-the Switch is provisioned.  Also you may have to allocate space on a NFS mount
-before installing a VM.  This is where Dependancies come in, allowing a Foundation
-to Depend on a Structure being build, and/or a job being run on a Structure.
+One final piece of the deployment puzzle, the **Dependency**.  This is to make sure
+your deployments happen in order.  For example, you can't install any OSes until
+the Switch is provisioned.  Also you may have to allocate space on an NFS mount
+before installing a VM.  This is where Dependencies come in, allowing a Foundation
+to Depend on a Structure being built, and/or a job being run on a Structure.
 
 
 BluePrints
 ----------
 
-Now that we have talked about the parts, we need to talk about how thoes things
-are confugred and that is handled by **BluePrint**, specifially the
+Now that we have talked about the parts, we need to talk about how those things
+are confugred and that is handled by **BluePrint**, specifically the
 **FoundationBluePrint** and the **StructureBluePrint**.  A Blueprint also holds
 cocnfiguration values, as well as links to scripts which are executed when the
 Structure/Foundation that blueprint is for is configured, destroyed, or had a named
@@ -284,6 +284,6 @@ Structure/Foundation.
 Other
 -----
 
-There are other Classes/Components in Contractor, but they are mostlly for dealing
-with Configure/Destroy/Misc Jobs (the Formen module).  As well as keeping track
-of Ip Addresses and other "Utilities".  Thoes are documented else where.
+There are other Classes/Components in Contractor, but they are mostly for dealing
+with Configure/Destroy/Misc Jobs (the Forman module).  As well as keeping track
+of Ip Addresses and other "Utilities".  Those are documented elsewhere.

--- a/_sources/contractor/IpAddresses.txt
+++ b/_sources/contractor/IpAddresses.txt
@@ -1,28 +1,28 @@
 Ip Addresses
 ============
 
-Ip Address come in a few flavors, there is a BaseAddress class which all Ip Addresses
+Ip Addresses come in a few flavors, there is a BaseAddress class which all Ip Addresses
 belong to that defines an Ip Address as an Offset in an AddressBlock.  The flavors
-of BaseAddress are **Address** - an Address that can belond to **Networked**.
-**ReservedAddress** - an Address that is reserved by something outside Contractors
+of BaseAddress are **Address** - an Address that can belong to **Networked**.
+**ReservedAddress** - an Address that is reserved by something outside Contractor's
 scope.  And **DynamicAddress** - an Address that belongs to a DHCP group.
 
-An **AddressBlock** is defined by it's network and prefix.  And can optionally
-hold a gateway offset.  No two AddressBlocks can overlap.  A AddressBlock is
+An **AddressBlock** is defined by its network and prefix and can optionally
+hold a gateway offset.  No two AddressBlocks can overlap.  An AddressBlock is
 also tied to a Site.
 
-**Address** can belong to anything that is **Networked**, Structures are Networked,
+**Address** can belong to anything that is **Networked**. Structures are Networked,
 as well as some Foundations like the IPMIFoundation.  An Address enforces that the
 Site the Networked belongs to is the same as the AddressBlock the Address Belongs to,
-thereby simplifying mahangment, helping to assure that the address will work.  Sites
+thereby simplifying management, helping to assure that the address will work.  Sites
 can also hold network configuration information (such as DNS servers and DNS
 search zones) which can be Site specfic.  Address also adds optional vLAN value, as
 well as an optional sub-interface value.  In some cases (such as with containers),
-a Structure dosen't have it's own IpAddress, but relys on it's host IpAddress.  In
+a Structure doesn't have it's own IpAddress, but relies on its host IpAddress.  In
 these cases, Address can be configured to point to another Address.  Address also
 has a binary value is_primary, which defines which of all the potential Addresses
 this Networked device is to be used as it's primary DNS name, as well as the Address
-to use when refering to it.  NOTE: the site is not checked through the pointer
+to use when referring to it.  NOTE: the site is not checked through the pointer
 field, this way the host and the hosted can belond to diferent sites, make sure
 your site and network configuration works for this.
 
@@ -30,38 +30,38 @@ your site and network configuration works for this.
 the Address has been reserved.
 
 **DynamicAddress** adds a PXE value which is used to PXE boot what ever device
-get's this lease and want's to PXE boot, this is optional.
+gets this lease and wants to PXE boot.  This is optional.
 
-Releated to Addresses is the **NetworkInterface**.  A NetworkInterface is a named
+Related to Addresses is the **NetworkInterface**.  A NetworkInterface is a named
 connection between a Networked and a set of IpAddressed.  A NetworkInterface has a
 flag is_provisioning which indicates which interface should be used for communication
-during provisioning.  During provisioning only the primary ip on the privisioning
-interface is used.  Not until the final Structure(ie: Operating System) is installed
+during provisioning.  During provisioning only the primary IP on the provisioning
+interface is used.  Not until the final Structure(i.e., Operating System) is installed
 and configured will the other interfaces and Ip Addresses be used.  NetworkInterface
 has three flavors, **RealNetworkInterface**, **AbstractNetworkInterface**, and
-**AggragatedNetworkInterface**.
+**AggregatedNetworkInterface**.
 
-**RealNetworkInterface** is to identify physicall ports, (or in case of things like
-Blades/VMs, Real as far as the OS/BIOS is concerend).  This type requires a MAC address
+**RealNetworkInterface** is to identify physical ports, (or in case of things like
+Blades/VMs, Real as far as the OS/BIOS is concerned).  This type requires a MAC address
 and is PXE bootable.
 
 **AbstractNetworkInterface** is for interfaces that do not "physically" exist, like
 internal bridge interfaces, or loop back interfaces.
 
-**AggragatedNetworkInterface** is for grouping multiple NetworkInterfaces togeather
+**AggregatedNetworkInterface** is for grouping multiple NetworkInterfaces together
 into a single AbstractNetworkInterface.  This is for things such as Port Channels,
 Bonded Interfaces, LACP, etc.  One interface is designated as the master interface.
-When the finaly Structure is not installed and configured, this is the interface
+When the final Structure is not installed and configured, this is the interface
 that is used.  There is also a list of the other interfaces that are grouped
-in.  As well as a Key/Value field to store configuration information (such as
+in as well as a Key/Value field to store configuration information (such as
 the bonding mode).
 
-NOTE: All networking information is combined togeather and added to the Configuration
+NOTE: All networking information is combined together and added to the Configuration
 Information of the Structure/Foundation as a whole.
 
-NOTE2: Techinically speaking other than dedicated NetworkInterfaces, Such as the IPMI
-port on the IPMIFoundation, Foundationes do not have Ip Addresses.  Thus most Physicall
-Foundations will barrow the Address information of the Structure that they are configured
+NOTE2: Technically speaking other than dedicated NetworkInterfaces, such as the IPMI
+port on the IPMIFoundation, Foundations do not have Ip Addresses.  Thus most Physical
+Foundations will borrow the Address information of the Structure that they are configured
 with to do tasks of the Foundation Jobs.  Without a Structure, Foundation Jobs that
-require an Address can not be done. (This is something that will hopfully change
-in the future by barrowing from a dynamic poll, but for now a Structure is required)
+require an Address can not be done. (This is something that will hopefully change
+in the future by borrowing from a dynamic pool, but for now a Structure is required.)

--- a/_sources/contractor/Modules.txt
+++ b/_sources/contractor/Modules.txt
@@ -4,16 +4,16 @@ Modules
 BluePrint
 ---------
 
-Containes BluePrint a generic base class for StructureBluePrint and FoundationBluePrint.
-Also contains the Scripts and linckages between the BluePrints and Scripts.  And
+Contains BluePrint, a generic base class for StructureBluePrint and FoundationBluePrint.
+Also contains the Scripts and linkages between the BluePrints and Scripts.  It also contains
 PXE, things to which PXE bootable devices can be set to boot to.
 
 Building
 --------
 
-Contains Foundation a generic base class for all Foundations provided by plugins.
-Structure the class for Structures that go on Foundations.  Complex, a
-grouping of Foundations (ie: a cluster).  Dependancy, allows Foundations to
+Contains Foundation, a generic base class for all Foundations provided by plugins.
+Structure, the class for Structures that go on Foundations.  Complex, a
+grouping of Foundations (ie: a cluster).  Dependency, allows Foundations to
 depend on Structures and/or jobs to be complete on a structure.
 
 Foreman
@@ -26,29 +26,29 @@ respectivly.
 Site
 ----
 
-Contains Site, for grouping Foundations and Structurres into logical groups for
-easier managment.
+Contains Site, for grouping Foundations and Structures into logical groups for
+easier management.
 
 SubContractor
 -------------
 
-interface for subcontractor, probably going to get moved to Foreman
+Interface for Subcontractor, probably going to get moved to Foreman
 
 User
 ----
 
-Handels Contractor Users.
+Handles Contractor Users.
 
 Utilities
 ---------
 
-Handels Network Interfaces, Ip Addresses, and Power interfaces (Not  all flushed out yet)
+Handles Network Interfaces, Ip Addresses, and Power interfaces (Not all flushed out yet)
 
 
 lib
 ---
 
-Common utilties for all of  Contractor
+Common utilties for all of Contractor
 
 tscript
 -------

--- a/_sources/contractor/TryIt.txt
+++ b/_sources/contractor/TryIt.txt
@@ -22,15 +22,15 @@ Installing
 
 Create an Ubuntu Xenial VM, name it `contractor`, set the fqdn to `contractor.site1.local`
 Ideally it should be in a /24 network.  Ip addresses offsets from 2 to 20 will be
-set as reserved (so that contractor will not auto asign them) and offsets 21 - 29
-will be used for a dynamic DHCP pool. Offset 1 is assumed to te be the gateway.
+set as reserved (so that Contractor will not auto asign them) and offsets 21 - 29
+will be used for a dynamic DHCP pool. Offset 1 is assumed to be the gateway.
 All these values can be adjusted either in the setupWizzard file before it is run,
-or after it setup, you can use the API/UI to edit these values.
-The DNS setver will be set for the contractor VM, and bind on the contractor vm will
-be set to forward to the DNS server that was origionally configured on the VM.
+or after it is setup, you can use the API/UI to edit these values.
+The DNS server will be set for the contractor VM, and bind on the contractor vm will
+be set to forward to the DNS server that was originally configured on the VM.
 
 The default when installing from package is to use postgres for the database.
-sqlite is also supported, and the prefered way for developmnet.  You can edit the
+sqlite is also supported, and the prefered way for development.  You can edit the
 `/etc/contractor/master.conf` just before the `manage.py migrate` command to
 enable the sqlite option if desired, make sure to skip the postgres setup.  Keep
 in mind that sqlite option requires making the database writeable by `www-data.www-data`.
@@ -108,9 +108,9 @@ Now to disable the extra apache site::
   a2dissite 000-default
   service apache2 reload
 
-you might want to tweek /etc/apache2/sites-available/contractor.conf
+You might want to tweek /etc/apache2/sites-available/contractor.conf
 
-yon now take a look at the contractor ui at http://<contractor ip>
+You now take a look at the contractor ui at http://<contractor ip>
 
 now we will install subcontractor::
 
@@ -121,8 +121,8 @@ now we will install subcontractor::
 
 now edit /etc/subcontractor.conf
 enable the modules you want to use, remove the ';' and set the 0 to a 1.
-The 1 means one task for that plugin at a time, if you want things to go faster,
-you can try 2 or 4.  Depending on the plugin, the resources of your vm, etc.
+The 1 means one task for that plugin at a time. If you want things to go faster,
+you can try 2 or 4 depending on the plugin, the resources of your vm, etc.
 
 edit /etc/subcontractor.conf in the dhcpd section, make sure interface and tftp_server
 are correct, tftp_server should be the ip of the vm
@@ -138,7 +138,7 @@ make sure it's running::
   systemctl status dhcpd
 
 optional, edit /etc/default/tftpd-hpa and add '-v ' to TFTP_OPTIONS.  This will
-cause tfptd to log transfers to syslog.  This can be helpfull in troubleshooting
+cause tfptd to log transfers to syslog.  This can be helpful in troubleshooting
 boot problems. Make sure to run `service tftpd-hpa restart` to reload.
 
 to service static resources (such as the OS installers) you will need to setup

--- a/_sources/contractor/TryIt_packaged.txt
+++ b/_sources/contractor/TryIt_packaged.txt
@@ -5,9 +5,9 @@ Building Packages
 -----------------
 
 NOTE: To build the packages, you will need a temporary Ubuntu Xenial install, you can
-use the target contractor VM if you don't mind a little extra stuff laying arround.
+use the target Contractor VM if you don't mind a little extra stuff laying arround.
 
-install the required build tools, the PPA has a few required packages for building
+Install the required build tools, the PPA has a few required packages for building
 and installing::
 
   add-apt-repository ppa:pnhowe/t3kton
@@ -16,7 +16,7 @@ and installing::
 
 Create an empty directory, and cd into it
 
-first clone the contractor and related projects::
+First clone the contractor and related projects::
 
   git clone https://github.com/T3kton/contractor.git
   git clone https://github.com/T3kton/contractor_plugins.git
@@ -24,26 +24,26 @@ first clone the contractor and related projects::
   git clone https://github.com/T3kton/subcontractor_plugins.git
   git clone https://github.com/T3kton/resources.git
 
-now to build Contractor, first we need to get the node requirements for the UI, and fix a bug with react-toolbox::
+Now to build Contractor, first we need to get the node requirements for the UI, and fix a bug with react-toolbox::
 
   cd contractor
   cd ui && npm install && cd ..
   sed s/"export Ripple from '.\/ripple';"/"export { default as Ripple } from '.\/ripple';"/ -i ui/node_modules/react-toolbox/components/index.js
   sed s/"export Tooltip from '.\/tooltip';"/"export { default as Tooltip } from '.\/tooltip';"/ -i ui/node_modules/react-toolbox/components/index.js
 
-now build the packages::
+Now build the packages::
 
   make dpkg
   make respkg
   mv *.respkg ..
   cd ..
 
-now to build the others::
+Now to build the others::
 
   for i in subcontractor contractor_plugins subcontractor_plugins; do cd $i && make dpkg && cd ..; done
 
-and build the resources, the make in the resources can take a while, you may want
-to add `-j4` (replace the 4 with the number of compile process to parralaize)::
+And build the resources.  The make in the resources can take a while, you may want
+to add `-j4` (replace the 4 with the number of compile process to parallelize)::
 
   cd contractor_plugins
   make respkg
@@ -53,9 +53,9 @@ to add `-j4` (replace the 4 with the number of compile process to parralaize)::
   mv *.respkg ..
   cd ..
 
-copy the .deb and .respkg files from the build server to the target contractor vm.
+Copy the .deb and .respkg files from the build server to the target Contractor vm.
 
-on the target contractor vm setup repos and install some required tools::
+On the target Contractor vm setup repos and install some required tools::
 
   add-apt-repository ppa:pnhowe/t3kton
   apt update

--- a/_sources/contractor/TryIt_source.txt
+++ b/_sources/contractor/TryIt_source.txt
@@ -3,7 +3,7 @@ Install From Source
 
 Building requires running on a Ubuntu Xenial machine.
 
-install the required build tools, the PPA has a few required packages for building
+Install the required build tools, the PPA has a few required packages for building
 and installing::
 
   add-apt-repository ppa:pnhowe/t3kton
@@ -12,7 +12,7 @@ and installing::
 
 Create an empty directory, and cd into it
 
-first clone the contractor and related projects::
+First clone the contractor and related projects::
 
   git clone https://github.com/T3kton/contractor.git
   git clone https://github.com/T3kton/contractor_plugins.git
@@ -20,7 +20,7 @@ first clone the contractor and related projects::
   git clone https://github.com/T3kton/subcontractor_plugins.git
   git clone https://github.com/T3kton/resources.git
 
-now to build Contractor, first we need to get the node requirements for the UI, and fix a bug with react-toolbox::
+Now to build Contractor, first we need to get the node requirements for the UI, and fix a bug with react-toolbox::
 
   cd contractor
   cd ui && npm install
@@ -28,11 +28,11 @@ now to build Contractor, first we need to get the node requirements for the UI, 
   sed s/"export Tooltip from '.\/tooltip';"/"export { default as Tooltip } from '.\/tooltip';"/ -i ui/node_modules/react-toolbox/components/index.js
   cd ..
 
-and build the resources, the make in the resources can take a while, you may want to replace the 2 of the `-j2` with the number of cores you are using::
+and build the resources. The make in the resources can take a while, you may want to replace the 2 of the `-j2` with the number of cores you are using::
 
   for i in contractor contractor_plugins resources; do cd $i && make -j2 respkg && mv *.respkg .. && cd ..; done
 
-now to install the python, NOTE the Makefile will call './setup.py install' for you::
+Now to install the python, NOTE the Makefile will call './setup.py install' for you::
 
   cd contractor
   DESTDIR=/ make install

--- a/_sources/contractor/index.txt
+++ b/_sources/contractor/index.txt
@@ -31,44 +31,44 @@ Overview
 Contractor is a builder of anything, and is targeted to be used as a generic API
 to create/destroy/manipluate your resources no matter where or what they are.
 This enables you to focus on what you want to make, and not have to worry about
-the details and diferences in deployment.
+the details and differences in deployment.
 
-To acomplish this Contractor breaks deployment/provisioning into two parts.  A
+To acomplish this, Contractor breaks deployment/provisioning into two parts.  A
 Structure, or what it is you want to deploy, and a Foundation, or what you want
 to deploy it on.  Examples of Foundations are VirtualBox VMs, Docker Containers,
-Servers with IPMI, Servers with out out-of-band controll, Switches, PDUs, AWS, GCD,
+Servers with IPMI, Servers with out out-of-band control, Switches, PDUs, AWS, GCD,
 or just about anything else.  A Structure would be a DNS server, API Endpoint,
 Load Balanacer, Web Server, Docker Host, VirtualBox Host, CoreOS Server, etc.  To
 describe a Structure, a BluePrint is used.  This BluePrint describes configuration
 information needed to create the Structure.  There are also BluePrints for Foundations,
-which describe firmwares, machine level configuration (ie: IPMI configuration ), as
+which describe firmware, machine level configuration (i.e., IPMI configuration ), as
 well as contain information to fingerprint foundations, for example a Foundation
-BluePrint can require a certin number of CPUs and Memory, PCI devices, as well
+BluePrint can require a certain number of CPUs and Memory, PCI devices, as well
 as storage details.  Each Structure and Foundation belong to a grouping called
 a Site.  Sites can belong to other Sites, and a Structure does not need to belong
-to the same Site as it's foundation.  The Site can also contain configuration
+to the same Site as its foundation.  The Site can also contain configuration
 information that the Structures and Foundations that belong to it inherit.
 This way a configuration such as DNS Server can be maintained at the Site level
 and automatically propagate to everything inside that Site.
 
-At it's core Contractor has a scripting language called TScript.  Each BluePrint
+At its core Contractor has a scripting language called TScript.  Each BluePrint
 has a Create and Destroy script that is executed to create and destroy that Structure
-or in the case of Foundations, provision and deprovision.  Utility scripts can also
+or in the case of Foundations, provision and de-provision.  Utility scripts can also
 be created, for example, if a new firmware for a storage controller is released.
 A utility script can be created to deploy this new firmware, and a Job can be created
 to execute the script.  Jobs are run by the Foreman subsystem.  When a new Foundation
 has been detected, or a Structure's Foundation has been provisioned, Foreman will
-provide instructions to a SubContractor daemon to do indivitual tasks required
+provide instructions to a SubContractor daemon to do individual tasks required
 for that Foundation to be Provisioned or Structure to be created.
 
 SubContractor is a daemon that is run in appropriate parts of the network for
-handeling tasks as requested by the Script being executed in the Job.  All tasks
-are ask for by SubContracor, over HTTP (fully proxyable) thus Contractor it's
-self does not have to have access to sensitive parts of the network, it only
-needs to be visiable to SubContractor.  Each SubContractor can be configured to
-only do certian types of work.  For example a SubContractor can be configured to
-do only IPMI tasks enabeling the IPMI network to be isolated from other networks.
-Other SubContractors can then handel PXE booting the servers and perform other checks
+handling tasks as requested by the Script being executed in the Job.  All tasks
+are asked for by SubContracor, over HTTP (fully proxyable) thus Contractor itself
+does not have to have access to sensitive parts of the network, it only
+needs to be visible to SubContractor.  Each SubContractor can be configured to
+only do certain types of work.  For example, a SubContractor can be configured to
+do only IPMI tasks enabling the IPMI network to be isolated from other networks.
+Other SubContractors can then handle PXE booting the servers and perform other checks
 such as checking to see if port 22 is open (a common and easy way to make sure
 a Structure with SSH installed has sucessfully booted).
 
@@ -76,16 +76,16 @@ a Structure with SSH installed has sucessfully booted).
 Future
 ------
 Contractor being able to build everything can also be used as a single source of
-truth.  Thus providing a place where you can ask questions such as "How many Load
-Ballancers do we have", "What Services will taking this host down affect", or
+truth, thus providing a place where you can ask questions such as "How many Load
+Balancers do we have", "What Services will taking this host down affect", or
 "How many VM resources are being used to support this service".  Contractor has a
 Bind zone file generating ability that can be used to maintain DNS records, which
-will automatially update when things are added/removed.  With Contractor you do
+will automatically update when things are added/removed.  With Contractor you do
 not have to wait for a new VM to register with a service.  That Service can query
-Contractor to know what should be  registered with it, and act if a registered
-resource is not connected.  Contractor will also  have webhooks, so services can
+Contractor to know what should be registered with it and act if a registered
+resource is not connected.  Contractor will also have webhooks so that services can
 be notified on Creation/Destruction events or even hardware events, thus allowing
-a service to be able to ask for a harddrive replacment to wait until it is able
+a service able to ask for a harddrive replacment to wait until it is able
 to take that harddrive out of service nicely.
 
 
@@ -95,7 +95,7 @@ Installation
 After installing the python source, you need to setup the database.  First setup
 the DATABASE section of the settings.py file.  See
 https://docs.djangoproject.com/en/1.8/ref/settings/#databases for documentation
-on database setup.  The settings.py file is preconfigured to use  sqlite and store
+on database setup.  The settings.py file is preconfigured to use sqlite and store
 the database in parent directory of the settings.py file.  After the database
 connection is setup, create the the database::
 


### PR DESCRIPTION
Hey, I cleaned up a bunch of the docs text.  A few tricky spots:
Is "dependency" spelled as "dependancy" all through the code?  I changed those but maybe they should keep the "a" if that's how you coded it. 
Same with "aggregated" vs. "aggragated"
One other spot was I wanted to cap "IP" but your class might really be "Ip Address" so I left that.